### PR TITLE
Set master node as an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ To create a standalone cluster with [docker-compose](http://docs.docker.com/comp
 The SparkUI will be running at `http://${YOUR_DOCKER_HOST}:8080` with one worker listed. To run `spark-shell`, exec into a container:
 
     docker exec -it dockerspark_master_1 /bin/bash
-    /usr/spark/bin/spark-shell --master spark://master:7077
+    /usr/spark/bin/spark-shell
 
 To run `SparkPi`, exec into a container:
 
     docker exec -it dockerspark_master_1 /bin/bash
-    MASTER=spark://master:7077 /usr/spark/bin/run-example SparkPi 10
+    /usr/spark/bin/run-example SparkPi 10
 
 ## license
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ master:
   hostname: master
   environment:
     SPARK_CONF_DIR: /conf
+    MASTER: spark://master:7077
   expose:
     - 7001
     - 7002


### PR DESCRIPTION
Sets a default master variable to simplify running most scripts.
