### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 master:
-  image: gettyimages/spark
+  image: gettyimages/spark:1.6.0-hadoop-2.6
   command: /usr/spark/bin/spark-class org.apache.spark.deploy.master.Master -h master
   hostname: master
   environment:
@@ -25,7 +25,7 @@ master:
     - ./data:/tmp/data
 
 worker:
-  image: gettyimages/spark
+  image: gettyimages/spark:1.6.0-hadoop-2.6
   command: /usr/spark/bin/spark-class org.apache.spark.deploy.worker.Worker spark://master:7077
   hostname: worker
   environment:


### PR DESCRIPTION
When running docker-compose with this version you will get latest image (currently 2.0.0).
By setting version tag in docker-compose.yaml you ensure requested version
