### PR TITLE
Add SPARK_PUBLIC_DNS env in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ master:
   environment:
     MASTER: spark://master:7077
     SPARK_CONF_DIR: /conf
+    SPARK_PUBLIC_DNS: localhost
   expose:
     - 7001
     - 7002
@@ -33,6 +34,7 @@ worker:
     SPARK_WORKER_MEMORY: 1g
     SPARK_WORKER_PORT: 8881
     SPARK_WORKER_WEBUI_PORT: 8081
+    SPARK_PUBLIC_DNS: localhost
   links:
     - master
   expose:


### PR DESCRIPTION
This triggers ability to use Spark UI as all links point to `localhost`
