### PR TITLE
Spark history server implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 *.tsv
 *.csv
 *.py
+/logs
+# Ignore the content of the spark-events (logs)
+# But keep the directory thanks to .gitkeep
+/spark-events
+!/**/.gitkeep

--- a/README.md
+++ b/README.md
@@ -34,6 +34,37 @@ To run `SparkPi`, exec into a container:
     docker exec -it dockerspark_master_1 /bin/bash
     bin/run-example SparkPi 10
 
+### Using the history server
+
+Spark comes with an history server, it provides a great UI with many information regarding Spark jobs execution (event timeline, detail of stages, etc.).
+Details can be found in the [Spark monitoring page][spark-monit].
+
+With this implementation, its UI will be running at `http://${YOUR_DOCKER_HOST}:18080`.
+
+To use the Spark’s history server you have to tell your Spark driver:
+
+* to log events: `spark.eventLog.enabled true` (it's `false` by default)
+* the log directory to use: `spark.eventLog.dir file:/tmp/spark-events`
+
+By default the `/tmp/spark-events` is mounted on the `./spark-events` at the root of the repo (I call it `$DOCKER_SPARK`).
+So you have to tell the driver to log events in this directory (on your local machine).
+
+This example shows this configuration for a `spark-submit` (the two `--conf` options): 
+
+    DOCKER_SPARK="/Users/xxxx/Git/docker-spark"
+
+    $SPARK_HOME/bin/spark-submit \
+      --class org.apache.spark.examples.SparkPi \
+      --master spark://localhost:7077 \
+      --conf "spark.eventLog.enabled=true" \
+      --conf "spark.eventLog.dir=file:$DOCKER_SPARK/spark-events" \
+      $SPARK_HOME/examples/jars/spark-examples_2.11-2.3.1.jar \
+      10
+
+*Note: This settings can be defined in the driver's `$SPARK_HOME/conf/spark-defaults.conf` to avoid using the `--conf` option.*
+
 ## license
 
 MIT
+
+[spark-monit]: https://spark.apache.org/docs/latest/monitoring.html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,3 +47,16 @@ worker:
   volumes:
     - ./conf/worker:/conf
     - ./data:/tmp/data
+
+history:
+  image: gettyimages/spark
+  command: bin/spark-class org.apache.spark.deploy.history.HistoryServer
+  hostname: history
+  environment:
+    SPARK_PUBLIC_DNS: localhost
+  expose:
+    - 18080
+  ports:
+    - 18080:18080
+  volumes:
+    - ./spark-events:/tmp/spark-events


### PR DESCRIPTION
Spark comes with a **history server**, it provides a great UI with many information regarding Spark jobs execution (event timeline, detail of stages, etc.).
Details can be found in the [Spark monitoring page][spark-monit].

I've modified the [gettyimages/docker-spark](https://github.com/gettyimages/docker-spark) to be able to run it with the `docker-compose up`command.

With this implementation, its UI will be running at `http://${YOUR_DOCKER_HOST}:18080`.

<img width="1102" alt="history-server" src="https://user-images.githubusercontent.com/7131913/49256860-b6f64300-f430-11e8-9d08-69ebf1920ff3.png">

To use the Spark’s history server you have to tell your Spark driver:

* to log events: `spark.eventLog.enabled true` (it's `false` by default)
* the log directory to use: `spark.eventLog.dir file:/tmp/spark-events`

By default the `/tmp/spark-events` is mounted on the `./spark-events` at the root of the repo (I call it `$DOCKER_SPARK`).
So you have to tell the driver to log events in this directory (on your local machine).

This example shows this configuration for a `spark-submit` (the two `--conf` options): 

    DOCKER_SPARK="/Users/xxxx/Git/docker-spark"

    $SPARK_HOME/bin/spark-submit \
      --class org.apache.spark.examples.SparkPi \
      --master spark://localhost:7077 \
      --conf "spark.eventLog.enabled=true" \
      --conf "spark.eventLog.dir=file:$DOCKER_SPARK/spark-events" \
      $SPARK_HOME/examples/jars/spark-examples_2.11-2.3.1.jar \
      10

*Note: This settings can be defined in the driver's `$SPARK_HOME/conf/spark-defaults.conf` to avoid using the `--conf` option.*

This comment comes from my [blog post][b-post].

[spark-monit]: https://spark.apache.org/docs/latest/monitoring.html
[b-post]: https://www.back2code.me/2018/11/spark-history-server-available-in-docker-spark/