### PR TITLE
Fix client version error following docker-compose issue 5103

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,49 +1,51 @@
-master:
-  image: gettyimages/spark
-  command: bin/spark-class org.apache.spark.deploy.master.Master -h master
-  hostname: master
-  environment:
-    MASTER: spark://master:7077
-    SPARK_CONF_DIR: /conf
-    SPARK_PUBLIC_DNS: localhost
-  expose:
-    - 7001
-    - 7002
-    - 7003
-    - 7004
-    - 7005
-    - 7077
-    - 6066
-  ports:
-    - 4040:4040
-    - 6066:6066
-    - 7077:7077
-    - 8080:8080
-  volumes:
-    - ./conf/master:/conf
-    - ./data:/tmp/data
+version: "2.2"
+services:
+  master:
+    image: gettyimages/spark
+    command: bin/spark-class org.apache.spark.deploy.master.Master -h master
+    hostname: master
+    environment:
+      MASTER: spark://master:7077
+      SPARK_CONF_DIR: /conf
+      SPARK_PUBLIC_DNS: localhost
+    expose:
+      - 7001
+      - 7002
+      - 7003
+      - 7004
+      - 7005
+      - 7077
+      - 6066
+    ports:
+      - 4040:4040
+      - 6066:6066
+      - 7077:7077
+      - 8080:8080
+    volumes:
+      - ./conf/master:/conf
+      - ./data:/tmp/data
 
-worker:
-  image: gettyimages/spark
-  command: bin/spark-class org.apache.spark.deploy.worker.Worker spark://master:7077
-  hostname: worker
-  environment:
-    SPARK_CONF_DIR: /conf
-    SPARK_WORKER_CORES: 2
-    SPARK_WORKER_MEMORY: 1g
-    SPARK_WORKER_PORT: 8881
-    SPARK_WORKER_WEBUI_PORT: 8081
-    SPARK_PUBLIC_DNS: localhost
-  links:
-    - master
-  expose:
-    - 7012
-    - 7013
-    - 7014
-    - 7015
-    - 8881
-  ports:
-    - 8081:8081
-  volumes:
-    - ./conf/worker:/conf
-    - ./data:/tmp/data
+  worker:
+    image: gettyimages/spark
+    command: bin/spark-class org.apache.spark.deploy.worker.Worker spark://master:7077
+    hostname: worker
+    environment:
+      SPARK_CONF_DIR: /conf
+      SPARK_WORKER_CORES: 2
+      SPARK_WORKER_MEMORY: 1g
+      SPARK_WORKER_PORT: 8881
+      SPARK_WORKER_WEBUI_PORT: 8081
+      SPARK_PUBLIC_DNS: localhost
+    links:
+      - master
+    expose:
+      - 7012
+      - 7013
+      - 7014
+      - 7015
+      - 8881
+    ports:
+      - 8081:8081
+    volumes:
+      - ./conf/worker:/conf
+      - ./data:/tmp/data


### PR DESCRIPTION
This should fix #48 following the discussion in this issue in the docker-compose repo: [client version 1.22 is too old. Minimum supported API version is 1.25](https://github.com/docker/compose/issues/5103).

It sets the version of the compose file.